### PR TITLE
Closes "Add errors for username generation on client node startup #119"

### DIFF
--- a/bugbounty.md
+++ b/bugbounty.md
@@ -1,0 +1,11 @@
+# Bug Bounties with Immunefi
+
+## Overview
+
+This bug bounty document verifies that Lido hosts a bug bounty on Immunefi at the address [https://immunefi.com/bounty/lido/](https://immunefi.com/bounty/lido/).
+
+If you have found a vulnerability in our project, it must be submitted through [Immunefi's platform](https://immunefi.com/). Immunefi will handle bug bounty communications.
+
+See the bounty page at Immunefi for more details on accepted vulnerabilities, payout amounts, and rules of participation.
+
+Users who violate the rules of participation will not receive bug bounty payouts and may be temporarily suspended or banned from the bug bounty program.

--- a/cmd/dc4bc_d/main.go
+++ b/cmd/dc4bc_d/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/lidofinance/dc4bc/fsm/config"
 	"log"
 	"os"
 	"os/signal"
@@ -90,6 +91,15 @@ func genKeyPairCommand() *cobra.Command {
 		Short: "generates a keypair to sign and verify messages",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			username := viper.GetString(flagUserName)
+
+			if len(username) < config.UsernameMinLength {
+				return fmt.Errorf("\"username\" minimum length is %d", config.UsernameMinLength)
+			}
+
+			if len(username) > config.UsernameMaxLength {
+				return fmt.Errorf("\"username\" maximum length is %d", config.UsernameMaxLength)
+			}
+
 			keyStoreDBDSN := viper.GetString(flagStoreDBDSN)
 
 			keyPair := client.NewKeyPair()

--- a/fsm/config/config.go
+++ b/fsm/config/config.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// Signature proposal
 	UsernameMinLength                         = 3
-	UsernameMaxLength                         = 15
+	UsernameMaxLength                         = 150
 	ParticipantPubKeyMinLength                = 10
 	DkgPubKeyMinLength                        = 10
 	SignatureProposalSigningThresholdMinCount = 2

--- a/fsm/config/config.go
+++ b/fsm/config/config.go
@@ -3,8 +3,18 @@ package config
 import "time"
 
 const (
-	ParticipantsMinCount                  = 2
-	SignatureProposalConfirmationDeadline = time.Hour * 24 * 7
-	DkgConfirmationDeadline               = time.Hour * 24 * 7
-	SigningConfirmationDeadline           = time.Hour * 24 * 7
+	// Signature proposal
+	UsernameMinLength                         = 3
+	UsernameMaxLength                         = 15
+	ParticipantPubKeyMinLength                = 10
+	DkgPubKeyMinLength                        = 10
+	SignatureProposalSigningThresholdMinCount = 2
+	ParticipantsMinCount                      = 2
+	SignatureProposalConfirmationDeadline     = time.Hour * 24 * 7
+
+	// DKG
+	DkgConfirmationDeadline = time.Hour * 24 * 7
+
+	// Signing
+	SigningConfirmationDeadline = time.Hour * 24 * 7
 )

--- a/fsm/types/requests/signature_proposal_validation.go
+++ b/fsm/types/requests/signature_proposal_validation.go
@@ -12,8 +12,11 @@ func (r *SignatureProposalParticipantsListRequest) Validate() error {
 		return fmt.Errorf("too few participants, minimum is {%d}", config.ParticipantsMinCount)
 	}
 
-	if r.SigningThreshold < 2 {
-		return errors.New("{SigningThreshold} minimum count is {2}")
+	if r.SigningThreshold < config.SignatureProposalSigningThresholdMinCount {
+		return fmt.Errorf(
+			"{SigningThreshold} minimum count is {%d}",
+			config.SignatureProposalSigningThresholdMinCount,
+		)
 	}
 
 	if r.SigningThreshold > len(r.Participants) {
@@ -29,19 +32,19 @@ func (r *SignatureProposalParticipantsListRequest) Validate() error {
 	}
 
 	for _, participant := range r.Participants {
-		if len(participant.Username) < 3 {
-			return errors.New("{Username} minimum length is {3}")
+		if len(participant.Username) < config.UsernameMinLength {
+			return fmt.Errorf("{Username} minimum length is {%d}", config.UsernameMinLength)
 		}
 
-		if len(participant.Username) > 150 {
-			return errors.New("{Username} maximum length is {150}")
+		if len(participant.Username) > config.UsernameMaxLength {
+			return fmt.Errorf("{Username} maximum length is {%d}", config.UsernameMaxLength)
 		}
 
-		if len(participant.PubKey) < 10 {
+		if len(participant.PubKey) < config.ParticipantPubKeyMinLength {
 			return errors.New("{PubKey} too short")
 		}
 
-		if len(participant.DkgPubKey) < 10 {
+		if len(participant.DkgPubKey) < config.DkgPubKeyMinLength {
 			return errors.New("{DkgPubKey} too short")
 		}
 	}


### PR DESCRIPTION
- Added length validation for "--username" option
- Moved "magic numbers" to config.go constants