### PR TITLE
dc4bc_cli read_operation_result now returns error if provided operation is not "result" operation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -422,6 +422,10 @@ func (c *BaseClient) GetOperationQRPath(operationID string) (string, error) {
 // It checks that the operation exists in an operation pool, signs the operation, sends it to an append-only log and
 // deletes it from the pool.
 func (c *BaseClient) handleProcessedOperation(operation types.Operation) error {
+	if len(operation.ResultMsgs) == 0 {
+		return errors.New("operation is request operation, provide result operation instead")
+	}
+
 	storedOperation, err := c.state.GetOperationByID(operation.ID)
 	if err != nil {
 		return fmt.Errorf("failed to find matching operation: %w", err)


### PR DESCRIPTION
Closes #122