### PR TITLE
Remove duplicated http handlers code

### DIFF
--- a/client/api/http_api/context_service/context_service.go
+++ b/client/api/http_api/context_service/context_service.go
@@ -9,16 +9,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type ContextService struct {
-	echo.Context
-}
-
-func New(c echo.Context) *ContextService {
-	return &ContextService{
-		c,
-	}
-}
-
 type CSJsonResp struct {
 	Result interface{} `json:"result"`
 }
@@ -34,6 +24,16 @@ func (e *CSErrorResp) Error() string {
 		return ""
 	}
 	return e.ErrorMessage
+}
+
+func New(c echo.Context) *ContextService {
+	return &ContextService{
+		c,
+	}
+}
+
+type ContextService struct {
+	echo.Context
 }
 
 // BindToRequest populates the request fields based on the context path and query parameters and body

--- a/client/api/http_api/context_service/context_service.go
+++ b/client/api/http_api/context_service/context_service.go
@@ -2,7 +2,10 @@ package context_service
 
 import (
 	"fmt"
+	"net/http"
 
+	"github.com/censync/go-dto"
+	"github.com/censync/go-validator"
 	"github.com/labstack/echo/v4"
 )
 
@@ -31,6 +34,29 @@ func (e *CSErrorResp) Error() string {
 		return ""
 	}
 	return fmt.Sprintf("%s", e.ErrorMessage)
+}
+
+// BindToRequest populates the request fields based on the context path and query parameters and body
+// and validates the result.
+func (cs *ContextService) BindToRequest(request interface{}) error {
+	if err := cs.Bind(request); err != nil {
+		return cs.JsonError(http.StatusBadRequest, fmt.Errorf("failed to read request body: %v", err))
+	}
+	if err := validator.Validate(request); !err.IsEmpty() {
+		return cs.JsonError(http.StatusBadRequest, err.Error())
+	}
+	return nil
+}
+
+// BindToDTO builds a request of the given form based on the context and converts it to a DTO.
+func (cs *ContextService) BindToDTO(requestForm, dtoForm interface{}) error {
+	if err := cs.BindToRequest(requestForm); err != nil {
+		return err
+	}
+	if err := dto.RequestToDTO(dtoForm, requestForm); err != nil {
+		return cs.JsonError(http.StatusBadRequest, err)
+	}
+	return nil
 }
 
 func (cs *ContextService) Json(code int, data interface{}) error {

--- a/client/api/http_api/context_service/context_service.go
+++ b/client/api/http_api/context_service/context_service.go
@@ -33,7 +33,7 @@ func (e *CSErrorResp) Error() string {
 	if e == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s", e.ErrorMessage)
+	return e.ErrorMessage
 }
 
 // BindToRequest populates the request fields based on the context path and query parameters and body

--- a/client/api/http_api/handlers/fsm.go
+++ b/client/api/http_api/handlers/fsm.go
@@ -1,11 +1,8 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
-	"github.com/censync/go-dto"
-	"github.com/censync/go-validator"
 	"github.com/labstack/echo/v4"
 	. "github.com/lidofinance/dc4bc/client/api/dto"
 	cs "github.com/lidofinance/dc4bc/client/api/http_api/context_service"
@@ -14,65 +11,23 @@ import (
 
 func (a *HTTPApp) GetFSMDump(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.DkgIdForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &DkgIdDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.DkgIdForm{}, formDTO); err != nil {
+		return err
 	}
 
 	fsmDump, err := a.node.GetFSMDump(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			fsmDump,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, fsmDump)
 }
 
 func (a *HTTPApp) GetFSMList(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
 	fsmDump, err := a.node.GetFSMList()
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			fsmDump,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, fsmDump)
 }

--- a/client/api/http_api/handlers/messages.go
+++ b/client/api/http_api/handlers/messages.go
@@ -1,11 +1,8 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
-	"github.com/censync/go-dto"
-	"github.com/censync/go-validator"
 	"github.com/labstack/echo/v4"
 	. "github.com/lidofinance/dc4bc/client/api/dto"
 	cs "github.com/lidofinance/dc4bc/client/api/http_api/context_service"
@@ -14,47 +11,13 @@ import (
 
 func (a *HTTPApp) SendMessage(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.MessageForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &MessageDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.MessageForm{}, formDTO); err != nil {
+		return err
 	}
 
-	err = a.node.SendMessage(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			"ok",
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err := a.node.SendMessage(formDTO); err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, "ok")
 }

--- a/client/api/http_api/handlers/operations.go
+++ b/client/api/http_api/handlers/operations.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/censync/go-dto"
-	"github.com/censync/go-validator"
 	"github.com/labstack/echo/v4"
 	. "github.com/lidofinance/dc4bc/client/api/dto"
 	cs "github.com/lidofinance/dc4bc/client/api/http_api/context_service"
@@ -14,159 +12,49 @@ import (
 
 func (a *HTTPApp) GetOperations(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
 	operations, err := a.node.GetOperations()
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			operations,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, operations)
 }
 
 func (a *HTTPApp) ProcessOperation(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.OperationForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &OperationDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.OperationForm{}, formDTO); err != nil {
+		return err
 	}
 
-	err = a.node.ProcessOperation(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			"ok",
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err := a.node.ProcessOperation(formDTO); err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, "ok")
 }
 
 func (a *HTTPApp) GetOperation(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.OperationIdForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &OperationIdDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.OperationIdForm{}, formDTO); err != nil {
+		return err
 	}
 
 	operation, err := a.node.GetOperation(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			operation,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			fmt.Errorf("failed to get operations: %v", err),
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get operations: %v", err))
 	}
+	return stx.Json(http.StatusOK, operation)
 }
 
 func (a *HTTPApp) ApproveParticipation(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.OperationIdForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &OperationIdDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.OperationIdForm{}, formDTO); err != nil {
+		return err
 	}
 
-	err = a.node.ApproveParticipation(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			"ok",
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err := a.node.ApproveParticipation(formDTO); err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, "ok")
 }

--- a/client/api/http_api/handlers/qr.go
+++ b/client/api/http_api/handlers/qr.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/censync/go-dto"
-	"github.com/censync/go-validator"
 	"github.com/labstack/echo/v4"
 	. "github.com/lidofinance/dc4bc/client/api/dto"
 	cs "github.com/lidofinance/dc4bc/client/api/http_api/context_service"
@@ -14,91 +12,28 @@ import (
 
 func (a *HTTPApp) GetOperationQRPath(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.OperationIdForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &OperationIdDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.OperationIdForm{}, formDTO); err != nil {
+		return err
 	}
 
 	operations, err := a.node.GetOperationQRPath(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			operations,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			fmt.Errorf("failed to get operations: %v", err),
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get operations: %v", err))
 	}
+	return stx.Json(http.StatusOK, operations)
 }
 
 func (a *HTTPApp) GetOperationQRFile(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.OperationIdForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &OperationIdDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.OperationIdForm{}, formDTO); err != nil {
+		return err
 	}
 
 	encodedData, err := a.node.GetOperationQRFile(formDTO)
-
-	if err == nil {
-		return stx.Blob(http.StatusOK, "image/png", encodedData)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Blob(http.StatusOK, "image/png", encodedData)
 }

--- a/client/api/http_api/handlers/signatures.go
+++ b/client/api/http_api/handlers/signatures.go
@@ -2,11 +2,10 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 	"net/http"
 
-	dto "github.com/censync/go-dto"
-	"github.com/censync/go-validator"
+	"github.com/google/uuid"
+
 	"github.com/labstack/echo/v4"
 	. "github.com/lidofinance/dc4bc/client/api/dto"
 	cs "github.com/lidofinance/dc4bc/client/api/http_api/context_service"
@@ -15,121 +14,38 @@ import (
 
 func (a *HTTPApp) GetSignatures(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.DkgIdForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &DkgIdDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.DkgIdForm{}, formDTO); err != nil {
+		return err
 	}
 
 	signatures, err := a.node.GetSignatures(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			signatures,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			fmt.Errorf("failed to get operations: %v", err),
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get operations: %v", err))
 	}
+	return stx.Json(http.StatusOK, signatures)
 }
 
 func (a *HTTPApp) GetSignatureByID(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.SignatureByIDForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &SignatureByIdDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.SignatureByIDForm{}, formDTO); err != nil {
+		return err
 	}
 
 	signatures, err := a.node.GetSignatureByID(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			signatures,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			fmt.Errorf("failed to get operations: %v", err),
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get operations: %v", err))
 	}
+	return stx.Json(http.StatusOK, signatures)
 }
 
 func (a *HTTPApp) ProposeSignData(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.ProposeSignMessageForm{}
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &ProposeSignMessageDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
+	if err := stx.BindToDTO(&req.ProposeSignMessageForm{}, formDTO); err != nil {
+		return err
+	}
 
 	batch := ProposeSignBatchMessagesDTO{
 		DkgID: formDTO.DkgID,
@@ -138,70 +54,21 @@ func (a *HTTPApp) ProposeSignData(c echo.Context) error {
 		},
 	}
 
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := a.node.ProposeSignMessages(&batch); err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
-
-	err = a.node.ProposeSignMessages(&batch)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			"ok",
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
-	}
+	return stx.Json(http.StatusOK, "ok")
 }
 
 func (a *HTTPApp) ProposeSignBatchMessages(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.ProposeSignBatchMessagesForm{}
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &ProposeSignBatchMessagesDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.ProposeSignBatchMessagesForm{}, formDTO); err != nil {
+		return err
 	}
 
-	err = a.node.ProposeSignMessages(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			"ok",
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err := a.node.ProposeSignMessages(formDTO); err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, "ok")
 }

--- a/client/api/http_api/handlers/signatures.go
+++ b/client/api/http_api/handlers/signatures.go
@@ -40,7 +40,7 @@ func (a *HTTPApp) GetSignatureByID(c echo.Context) error {
 	return stx.Json(http.StatusOK, signatures)
 }
 
-func (a *HTTPApp) ProposeSignData(c echo.Context) error {
+func (a *HTTPApp) ProposeSignMessage(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &ProposeSignMessageDTO{}
 	if err := stx.BindToDTO(&req.ProposeSignMessageForm{}, formDTO); err != nil {

--- a/client/api/http_api/handlers/state.go
+++ b/client/api/http_api/handlers/state.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/censync/go-dto"
-	"github.com/censync/go-validator"
 	"github.com/labstack/echo/v4"
 	. "github.com/lidofinance/dc4bc/client/api/dto"
 	cs "github.com/lidofinance/dc4bc/client/api/http_api/context_service"
@@ -14,111 +12,36 @@ import (
 
 func (a *HTTPApp) SaveStateOffset(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.StateOffsetForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &StateOffsetDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.StateOffsetForm{}, formDTO); err != nil {
+		return err
 	}
 
-	err = a.node.SaveOffset(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			"ok",
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err := a.node.SaveOffset(formDTO); err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, "ok")
 }
 
 func (a *HTTPApp) GetStateOffset(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
 	offset, err := a.node.GetStateOffset()
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			offset,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			fmt.Errorf("failed to load offset: %v", err),
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to load offset: %v", err))
 	}
+	return stx.Json(http.StatusOK, offset)
 }
+
 func (a *HTTPApp) ResetState(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	request := &req.ResetStateForm{}
-
-	err := stx.Bind(request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			fmt.Errorf("failed to read request body: %v", err),
-		)
-	}
-
-	if err := validator.Validate(request); !err.IsEmpty() {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err.Error(),
-		)
-	}
-
 	formDTO := &ResetStateDTO{}
-
-	err = dto.RequestToDTO(formDTO, request)
-
-	if err != nil {
-		return stx.JsonError(
-			http.StatusBadRequest,
-			err,
-		)
+	if err := stx.BindToDTO(&req.ResetStateForm{}, formDTO); err != nil {
+		return err
 	}
 
 	newStateDbPath, err := a.node.ResetFSMState(formDTO)
-
-	if err == nil {
-		return stx.Json(
-			http.StatusOK,
-			newStateDbPath,
-		)
-	} else {
-		return stx.JsonError(
-			http.StatusInternalServerError,
-			err,
-		)
+	if err != nil {
+		return stx.JsonError(http.StatusInternalServerError, err)
 	}
+	return stx.Json(http.StatusOK, newStateDbPath)
 }

--- a/client/api/http_api/handlers/username.go
+++ b/client/api/http_api/handlers/username.go
@@ -9,11 +9,5 @@ import (
 
 func (a *HTTPApp) GetUsername(c echo.Context) error {
 	stx := c.(*cs.ContextService)
-
-	username := a.node.GetUsername()
-
-	return stx.Json(
-		http.StatusOK,
-		username,
-	)
+	return stx.Json(http.StatusOK, a.node.GetUsername())
 }

--- a/client/api/http_api/router/default_router.go
+++ b/client/api/http_api/router/default_router.go
@@ -24,7 +24,7 @@ func SetRouter(e *echo.Echo, authHandler echo.MiddlewareFunc, node node.NodeServ
 	e.GET("/getOperation", h.GetOperation)
 
 	e.POST("/startDKG", h.StartDKG)
-	e.POST("/proposeSignMessage", h.ProposeSignData)
+	e.POST("/proposeSignMessage", h.ProposeSignMessage)
 	e.POST("/proposeSignBatchMessages", h.ProposeSignBatchMessages)
 	e.POST("/approveDKGParticipation", h.ApproveParticipation)
 	e.POST("/reinitDKG", h.ReInitDKG)


### PR DESCRIPTION
https://lido.myjetbrains.com/youtrack/issue/LSC-134

what's been done:
- move duplicated request handling and conversion to ContextService
- bring a little change to names of signing proposal related endpoints in order to make them be named similarly