### PR TITLE
removed unused field from CSErrorResp struct #LSC-152

### DIFF
--- a/client/api/http_api/context_service/context_service.go
+++ b/client/api/http_api/context_service/context_service.go
@@ -15,7 +15,6 @@ type CSJsonResp struct {
 
 // Custom error
 type CSErrorResp struct {
-	Result       interface{} `json:"result"`
 	ErrorMessage string      `json:"error_message,omitempty"`
 }
 
@@ -80,12 +79,10 @@ func (cs *ContextService) JsonEmpty(code int) error {
 func (cs *ContextService) JsonError(code int, err error) error {
 	if err == nil {
 		return cs.JSON(code, &CSErrorResp{
-			Result:       struct{}{},
 			ErrorMessage: "undefined error",
 		})
 	} else {
 		return cs.JSON(code, &CSErrorResp{
-			Result:       struct{}{},
 			ErrorMessage: err.Error(),
 		})
 	}

--- a/client/api/http_api/handlers/signatures.go
+++ b/client/api/http_api/handlers/signatures.go
@@ -21,7 +21,7 @@ func (a *HTTPApp) GetSignatures(c echo.Context) error {
 
 	signatures, err := a.node.GetSignatures(formDTO)
 	if err != nil {
-		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get operations: %v", err))
+		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get signatures: %w", err))
 	}
 	return stx.Json(http.StatusOK, signatures)
 }
@@ -35,7 +35,7 @@ func (a *HTTPApp) GetSignatureByID(c echo.Context) error {
 
 	signatures, err := a.node.GetSignatureByID(formDTO)
 	if err != nil {
-		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get operations: %v", err))
+		return stx.JsonError(http.StatusInternalServerError, fmt.Errorf("failed to get signatures: %w", err))
 	}
 	return stx.Json(http.StatusOK, signatures)
 }

--- a/cmd/dc4bc_cli/main.go
+++ b/cmd/dc4bc_cli/main.go
@@ -278,7 +278,6 @@ func getSignatureRequest(host string, dkgID, dataHash string) (*SignatureRespons
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
-
 	var response SignatureResponse
 	if err = json.Unmarshal(responseBody, &response); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %v", err)


### PR DESCRIPTION
I did not find any reason why we should keep this field. After removing the field we are getting the clear error message.
```shell
./dc4bc_cli get_signature 111111111111111111111111111111111111111111111 2222222222222222222222222222222222222222222222222
Error: failed to get signatures: failed to get signatures: signature not found
```