### PR TITLE
move errors sending logic from context service to handlers

### DIFF
--- a/client/api/http_api/context_service/context_service.go
+++ b/client/api/http_api/context_service/context_service.go
@@ -2,7 +2,6 @@ package context_service
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/censync/go-dto"
 	"github.com/censync/go-validator"
@@ -15,7 +14,7 @@ type CSJsonResp struct {
 
 // Custom error
 type CSErrorResp struct {
-	ErrorMessage string      `json:"error_message,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
 }
 
 func (e *CSErrorResp) Error() string {
@@ -39,10 +38,10 @@ type ContextService struct {
 // and validates the result.
 func (cs *ContextService) BindToRequest(request interface{}) error {
 	if err := cs.Bind(request); err != nil {
-		return cs.JsonError(http.StatusBadRequest, fmt.Errorf("failed to read request body: %v", err))
+		return fmt.Errorf("failed to read request body: %w", err)
 	}
 	if err := validator.Validate(request); !err.IsEmpty() {
-		return cs.JsonError(http.StatusBadRequest, err.Error())
+		return fmt.Errorf("invalid request: %w", err.Error())
 	}
 	return nil
 }
@@ -53,7 +52,7 @@ func (cs *ContextService) BindToDTO(requestForm, dtoForm interface{}) error {
 		return err
 	}
 	if err := dto.RequestToDTO(dtoForm, requestForm); err != nil {
-		return cs.JsonError(http.StatusBadRequest, err)
+		return err
 	}
 	return nil
 }

--- a/client/api/http_api/handlers/dkg.go
+++ b/client/api/http_api/handlers/dkg.go
@@ -25,7 +25,7 @@ func (a *HTTPApp) StartDKG(c echo.Context) error {
 	defer ctx.Request().Body.Close()
 
 	if err := validator.Validate(request); !err.IsEmpty() {
-		return ctx.JsonError(http.StatusBadRequest, err.Error())
+		return ctx.JsonError(http.StatusBadRequest, fmt.Errorf("invalid request: %w", err.Error()))
 	}
 
 	formDTO := &StartDkgDTO{}
@@ -44,7 +44,7 @@ func (a *HTTPApp) ReInitDKG(c echo.Context) error {
 	request := &req.ReInitDKGForm{}
 	err := ctx.BindToRequest(request)
 	if err != nil {
-		return err
+		return ctx.JsonError(http.StatusBadRequest, err)
 	}
 
 	formDTO := &ReInitDKGDTO{ID: request.ID}

--- a/client/api/http_api/handlers/fsm.go
+++ b/client/api/http_api/handlers/fsm.go
@@ -13,7 +13,7 @@ func (a *HTTPApp) GetFSMDump(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &DkgIdDTO{}
 	if err := stx.BindToDTO(&req.DkgIdForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	fsmDump, err := a.fsm.GetFSMDump(formDTO)

--- a/client/api/http_api/handlers/messages.go
+++ b/client/api/http_api/handlers/messages.go
@@ -13,7 +13,7 @@ func (a *HTTPApp) SendMessage(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &MessageDTO{}
 	if err := stx.BindToDTO(&req.MessageForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	if err := a.node.SendMessage(formDTO); err != nil {

--- a/client/api/http_api/handlers/operations.go
+++ b/client/api/http_api/handlers/operations.go
@@ -23,7 +23,7 @@ func (a *HTTPApp) ProcessOperation(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &OperationDTO{}
 	if err := stx.BindToDTO(&req.OperationForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	if err := a.node.ProcessOperation(formDTO); err != nil {
@@ -39,7 +39,7 @@ func (a *HTTPApp) GetOperation(c echo.Context) error {
 	formDTO := &OperationIdDTO{}
 
 	if err := stx.BindToDTO(request, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	operation, err := a.operation.GetOperationByID(formDTO.OperationID)
@@ -60,7 +60,7 @@ func (a *HTTPApp) ApproveParticipation(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &OperationIdDTO{}
 	if err := stx.BindToDTO(&req.OperationIdForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	if err := a.node.ApproveParticipation(formDTO); err != nil {

--- a/client/api/http_api/handlers/signatures.go
+++ b/client/api/http_api/handlers/signatures.go
@@ -16,7 +16,7 @@ func (a *HTTPApp) GetSignatures(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &DkgIdDTO{}
 	if err := stx.BindToDTO(&req.DkgIdForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	signatures, err := a.signature.GetSignatures(formDTO)
@@ -30,7 +30,7 @@ func (a *HTTPApp) GetSignatureByID(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &SignatureByIdDTO{}
 	if err := stx.BindToDTO(&req.SignatureByIDForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	signatures, err := a.signature.GetSignatureByID(formDTO)
@@ -44,7 +44,7 @@ func (a *HTTPApp) ProposeSignMessage(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &ProposeSignMessageDTO{}
 	if err := stx.BindToDTO(&req.ProposeSignMessageForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	batch := ProposeSignBatchMessagesDTO{
@@ -64,7 +64,7 @@ func (a *HTTPApp) ProposeSignBatchMessages(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &ProposeSignBatchMessagesDTO{}
 	if err := stx.BindToDTO(&req.ProposeSignBatchMessagesForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	if err := a.node.ProposeSignMessages(formDTO); err != nil {

--- a/client/api/http_api/handlers/state.go
+++ b/client/api/http_api/handlers/state.go
@@ -14,7 +14,7 @@ func (a *HTTPApp) SaveStateOffset(c echo.Context) error {
 	stx := c.(*cs.ContextService)
 	formDTO := &StateOffsetDTO{}
 	if err := stx.BindToDTO(&req.StateOffsetForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	if err := a.node.SaveOffset(formDTO); err != nil {
@@ -37,7 +37,7 @@ func (a *HTTPApp) ResetState(c echo.Context) error {
 
 	formDTO := &ResetStateDTO{}
 	if err := stx.BindToDTO(&req.ResetStateForm{}, formDTO); err != nil {
-		return err
+		return stx.JsonError(http.StatusBadRequest, err)
 	}
 
 	newStateDbPath, err := a.fsm.ResetFSMState(formDTO)


### PR DESCRIPTION
A little improvement in terms of HTTP API responsibilities distribution that moves errors sending from context service to handlers. It fixes the bug case when handling continued on request validation or request to DTO transformation which led to double JSON sending.