### PR TITLE
Improve dc4bc_cli responses

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -13,6 +13,7 @@ type KafkaStorageConfig struct {
 	TlsConfig           string `mapstructure:"kafka_truststore_path"`
 	ProducerCredentials string `mapstructure:"producer_credentials"`
 	ConsumerCredentials string `mapstructure:"consumer_credentials"`
+	ReadDuration        string `mapstructure:"kafka_read_duration"`
 	Timeout             string `mapstructure:"kafka_timeout"`
 
 	IgnoredMessages    string `mapstructure:"storage_ignore_messages"`

--- a/client/services/node/node_service.go
+++ b/client/services/node/node_service.go
@@ -355,6 +355,15 @@ func (s *BaseNodeService) ProposeSignMessages(dtoMsg *dto.ProposeSignBatchMessag
 		return fmt.Errorf("failed to get FSM instance: %w", err)
 	}
 
+	fsmState, err := fsmInstance.State()
+	if err != nil {
+		return fmt.Errorf("failed to determine FSM instance state: %w", err)
+	}
+
+	if fsmState != sif.StateSigningIdle {
+		return fmt.Errorf("required FSM state is %s, but have %s", sif.StateSigningIdle, fsmState)
+	}
+
 	participantID, err := fsmInstance.GetIDByUsername(s.GetUsername())
 	if err != nil {
 		return fmt.Errorf("failed to get participantID: %w", err)

--- a/client/services/node/node_service.go
+++ b/client/services/node/node_service.go
@@ -349,7 +349,8 @@ func (s *BaseNodeService) ProposeSignMessages(dtoMsg *dto.ProposeSignBatchMessag
 		messagesToSign = append(messagesToSign, messageDataSign)
 	}
 
-	fsmInstance, err := s.fsmService.GetFSMInstance(hex.EncodeToString(dtoMsg.DkgID))
+	encodedDkgID := hex.EncodeToString(dtoMsg.DkgID)
+	fsmInstance, err := s.fsmService.GetFSMInstance(encodedDkgID, false)
 	if err != nil {
 		return fmt.Errorf("failed to get FSM instance: %w", err)
 	}
@@ -371,7 +372,7 @@ func (s *BaseNodeService) ProposeSignMessages(dtoMsg *dto.ProposeSignBatchMessag
 		return fmt.Errorf("failed to marshal SigningBatchProposalStartRequest: %w", err)
 	}
 
-	message, err := s.buildMessage(hex.EncodeToString(dtoMsg.DkgID), sif.EventSigningStart, batchBz)
+	message, err := s.buildMessage(encodedDkgID, sif.EventSigningStart, batchBz)
 	if err != nil {
 		return fmt.Errorf("failed to build message: %w", err)
 	}
@@ -506,7 +507,7 @@ func (s *BaseNodeService) reinitDKG(message storage.Message) error {
 	}
 
 	// save new comm keys into FSM to verify future messages
-	fsmInstance, err := s.fsmService.GetFSMInstance(req.DKGID)
+	fsmInstance, err := s.fsmService.GetFSMInstance(req.DKGID, true)
 	if err != nil {
 		return fmt.Errorf("failed to get FSM instance: %w", err)
 	}
@@ -570,7 +571,7 @@ func (s *BaseNodeService) processSignatureProposal(message storage.Message) erro
 }
 
 func (s *BaseNodeService) processMessage(message storage.Message) (*types.Operation, error) {
-	fsmInstance, err := s.fsmService.GetFSMInstance(message.DkgRoundID)
+	fsmInstance, err := s.fsmService.GetFSMInstance(message.DkgRoundID, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to getFSMInstance: %w", err)
 	}

--- a/client/services/node/node_service_test.go
+++ b/client/services/node/node_service_test.go
@@ -68,7 +68,7 @@ func TestClient_ProcessMessage(t *testing.T) {
 	t.Run("test_process_dkg_init", func(t *testing.T) {
 		fsm, err := state_machines.Create(dkgRoundID)
 		req.NoError(err)
-		fsmService.EXPECT().GetFSMInstance(dkgRoundID).Times(1).Return(fsm, nil)
+		fsmService.EXPECT().GetFSMInstance(dkgRoundID, true).Times(1).Return(fsm, nil)
 
 		senderKeyPair := keystore.NewKeyPair()
 		senderAddr := senderKeyPair.GetAddr()

--- a/cmd/dc4bc_cli/main.go
+++ b/cmd/dc4bc_cli/main.go
@@ -240,12 +240,17 @@ func getSignaturesCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to read configuration: %v", err)
 			}
-			signatures, err := getSignaturesRequest(listenAddr, args[0])
+			dkgID := args[0]
+			signatures, err := getSignaturesRequest(listenAddr, dkgID)
 			if err != nil {
 				return fmt.Errorf("failed to get signatures: %w", err)
 			}
 			if signatures.ErrorMessage != "" {
 				return fmt.Errorf("failed to get signatures: %s", signatures.ErrorMessage)
+			}
+			if len(signatures.Result) == 0 {
+				fmt.Printf("No signatures found for dkgID %s", dkgID)
+				return nil
 			}
 			for sigID, signature := range signatures.Result {
 				fmt.Printf("Signing ID: %s\n", sigID)

--- a/cmd/dc4bc_cli/main.go
+++ b/cmd/dc4bc_cli/main.go
@@ -654,7 +654,7 @@ func startDKGCommand() *cobra.Command {
 
 func approveDKGParticipationCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "approve_participation [OPERATION_ID]",
+		Use:   "approve_participation [operationID]",
 		Args:  cobra.ExactArgs(1),
 		Short: "approve participation in a DKG process",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/dc4bc_cli/main.go
+++ b/cmd/dc4bc_cli/main.go
@@ -956,6 +956,10 @@ func getFSMListCommand() *cobra.Command {
 				return fmt.Errorf("failed to make HTTP request to get FSM list: %v", resp.ErrorMessage)
 			}
 			fsms := resp.Result.(map[string]interface{})
+			if len(fsms) == 0 {
+				fmt.Printf("There are no FSMs yet")
+				return nil
+			}
 			for dkgID, state := range fsms {
 				fmt.Printf("DKG ID: %s - FSM state: %s\n", dkgID, state.(string))
 			}

--- a/cmd/dc4bc_d/main.go
+++ b/cmd/dc4bc_d/main.go
@@ -29,6 +29,7 @@ const (
 	flagKafkaConsumerCredentials = "consumer_credentials"
 	flagKafkaTrustStorePath      = "kafka_truststore_path"
 	flagKafkaConsumerGroup       = "kafka_consumer_group"
+	flagKafkaReadDuration        = "kafka_read_duration"
 	flagKafkaTimeout             = "kafka_timeout"
 	flagStoreDBDSN               = "key_store_dbdsn"
 	flagConfig                   = "config"
@@ -55,6 +56,7 @@ func init() {
 	rootCmd.PersistentFlags().String(flagKafkaConsumerCredentials, "consumer:consumerpass", "Consumer credentials for Kafka: username:password")
 	rootCmd.PersistentFlags().String(flagKafkaTrustStorePath, "certs/ca.pem", "Path to kafka truststore")
 	rootCmd.PersistentFlags().String(flagKafkaConsumerGroup, "", "Kafka consumer group")
+	rootCmd.PersistentFlags().String(flagKafkaReadDuration, "10s", "Duration of a single Kafka read messages subscription")
 	rootCmd.PersistentFlags().String(flagKafkaTimeout, "60s", "Kafka I/O Timeout")
 	rootCmd.PersistentFlags().String(flagStoreDBDSN, "./dc4bc_key_store", "Key Store DBDSN")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, flagConfig, "", "path to your config file")
@@ -73,6 +75,7 @@ func init() {
 	exitIfError(viper.BindPFlag(flagKafkaConsumerCredentials, rootCmd.PersistentFlags().Lookup(flagKafkaConsumerCredentials)))
 	exitIfError(viper.BindPFlag(flagKafkaTrustStorePath, rootCmd.PersistentFlags().Lookup(flagKafkaTrustStorePath)))
 	exitIfError(viper.BindPFlag(flagKafkaConsumerGroup, rootCmd.PersistentFlags().Lookup(flagKafkaConsumerGroup)))
+	exitIfError(viper.BindPFlag(flagKafkaReadDuration, rootCmd.PersistentFlags().Lookup(flagKafkaReadDuration)))
 	exitIfError(viper.BindPFlag(flagKafkaTimeout, rootCmd.PersistentFlags().Lookup(flagKafkaTimeout)))
 	exitIfError(viper.BindPFlag(flagStoreDBDSN, rootCmd.PersistentFlags().Lookup(flagStoreDBDSN)))
 	exitIfError(viper.BindPFlag(flagUserName, rootCmd.PersistentFlags().Lookup(flagUserName)))

--- a/mocks/serviceMocks/fsmservice_mock.go
+++ b/mocks/serviceMocks/fsmservice_mock.go
@@ -51,18 +51,18 @@ func (mr *MockFSMServiceMockRecorder) GetFSMDump(dto interface{}) *gomock.Call {
 }
 
 // GetFSMInstance mocks base method.
-func (m *MockFSMService) GetFSMInstance(dkgRoundID string) (*state_machines.FSMInstance, error) {
+func (m *MockFSMService) GetFSMInstance(dkgRoundID string, createIfMissing bool) (*state_machines.FSMInstance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFSMInstance", dkgRoundID)
+	ret := m.ctrl.Call(m, "GetFSMInstance", dkgRoundID, createIfMissing)
 	ret0, _ := ret[0].(*state_machines.FSMInstance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFSMInstance indicates an expected call of GetFSMInstance.
-func (mr *MockFSMServiceMockRecorder) GetFSMInstance(dkgRoundID interface{}) *gomock.Call {
+func (mr *MockFSMServiceMockRecorder) GetFSMInstance(dkgRoundID, createIfMissing interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFSMInstance", reflect.TypeOf((*MockFSMService)(nil).GetFSMInstance), dkgRoundID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFSMInstance", reflect.TypeOf((*MockFSMService)(nil).GetFSMInstance), dkgRoundID, createIfMissing)
 }
 
 // GetFSMList mocks base method.


### PR DESCRIPTION
https://lido.myjetbrains.com/youtrack/issue/LSC-190

## commands and changes 

### get_signatures:

**issue:** empty response for nonexistent DKG ID

**solution:** show the user a message that says that there is no signatures for the DKG ID (https://github.com/lidofinance/dc4bc/pull/183/commits/d81b7030bc9a9a17ad0b4b1417d582c1a73420c1)

### sign_data:

**issue:** calls with nonexistent DKG IDs returns a silly error:
```
Error: failed to make HTTP request to propose message to sign: failed to get participantID: {IDs} not initialized
```
it happens because the fsmService.GetFSMInstance creates an FSM instance in case there is no one for the given DKG ID, and in this case it creates a new one without any participant data and tries to sign data with an empty FSM

**solution:** make the creation optional for the FSM service and use that option properly (https://github.com/lidofinance/dc4bc/pull/183/commits/004bf8f333330a597dc344b6d85e037aeedb07ef)

### sign_data:

**issue:** calls with inappropriate fsm state returns a silly error:
```
Error: failed to make HTTP request to propose message to sign: failed to get participantID: {IDs} not initialized
```

**solution:** add state validation to BaseNodeService.ProposeSignMessages (https://github.com/lidofinance/dc4bc/pull/183/commits/302dcaddf0afb37f780fee16ae253887fd9fbc31)

### get_fsm_list:

**issue:** empty response for no FSMs

**solution:** show the user a message that says that there are no FSMs yet (https://github.com/lidofinance/dc4bc/pull/183/commits/eaa4beb6a4249482a9557f9191ef5a552b4a5b38)

### refresh_state:

**issue:** accidentally I encountered with the following error during testing the app after the above-mentioned changes: on refresh_state, I got an error:
```
Error: failed to make HTTP request to reset state: failed to send HTTP request: Post "http://localhost:8085/resetState": EOF
```
The reason was the reader being closed while being used by the node Poll method

**soultion:** close and reinitialise reader with a proper application of context (https://github.com/lidofinance/dc4bc/pull/183/commits/0cd099230e61b6817566f2c1d685e6e625b33572)
