### PR TITLE
LDC-03 reinitDKG Can Be Called Multiple Times With The Same ID

### DIFF
--- a/client/modules/state/state.go
+++ b/client/modules/state/state.go
@@ -24,6 +24,7 @@ type State interface {
 
 	SaveOffset(uint64) error
 	LoadOffset() (uint64, error)
+	GetOrError(key string) ([]byte, error)
 }
 
 type LevelDBState struct {
@@ -150,4 +151,18 @@ func MakeCompositeKey(prefix, key string) []byte {
 
 func MakeCompositeKeyString(prefix, key string) string {
 	return fmt.Sprintf("%s_%s", prefix, key)
+}
+
+func (s *LevelDBState) GetOrError(key string) ([]byte, error) {
+	s.Lock()
+	defer s.Unlock()
+	var (
+		value []byte
+		err   error
+	)
+	if value, err = s.stateDb.Get([]byte(key), nil); err != nil {
+		return nil, err
+	}
+
+	return value, nil
 }

--- a/client/services/node/node_service.go
+++ b/client/services/node/node_service.go
@@ -527,6 +527,15 @@ func (s *BaseNodeService) reinitDKG(message storage.Message) error {
 		return fmt.Errorf("failed to umarshal request: %v", err)
 	}
 
+	roundExist, existErr := s.fsmService.IsExist(req.DKGID)
+	if existErr != nil {
+		return existErr
+	}
+
+	if roundExist {
+		return nil
+	}
+
 	// temporarily fix cause we can't verify patch messages
 	// TODO: remove later
 	if !s.GetSkipCommKeysVerification() {

--- a/mocks/clientMocks/state_mock.go
+++ b/mocks/clientMocks/state_mock.go
@@ -119,3 +119,18 @@ func (mr *MockStateMockRecorder) Set(key, value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockState)(nil).Set), key, value)
 }
+
+// GetOrError mocks base method.
+func (m *MockState) GetOrError(key string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrError", key)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrError indicates an expected call of GetOrError.
+func (mr *MockStateMockRecorder) GetOrError(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrError", reflect.TypeOf((*MockState)(nil).GetOrError), key)
+}

--- a/mocks/serviceMocks/fsmservice_mock.go
+++ b/mocks/serviceMocks/fsmservice_mock.go
@@ -109,3 +109,18 @@ func (mr *MockFSMServiceMockRecorder) SaveFSM(dkgRoundID, dump interface{}) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveFSM", reflect.TypeOf((*MockFSMService)(nil).SaveFSM), dkgRoundID, dump)
 }
+
+// IsExist mocks base method.
+func (m *MockFSMService) IsExist(dkgRoundID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsExist", dkgRoundID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsExist indicates an expected call of IsExist.
+func (mr *MockFSMServiceMockRecorder) IsExist(dkgRoundID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExist", reflect.TypeOf((*MockFSMService)(nil).IsExist), dkgRoundID)
+}


### PR DESCRIPTION
**Description**

It is possible to send a message of type ReinitDKG which has the same DKG ID as the current round.
The most promiment issue that arises from sending a second Reinit DKG message is that it will update the communi-
cations key for each of the participants.
The following code snippet is taked from reinitDKG() which will be called if a malicious node submits a ReinitDKG message to the message storage. The malicious node may set DKGID to an arbitrary value, such as the current round ID.

```go
        // save new comm keys into FSM to verify future messages
        fsmInstance, err := s.fsmService.GetFSMInstance(req.DKGID, true)
	if err != nil {
		return fmt.Errorf("failed to get FSM instance: %w", err)
	}
	for _, reqParticipant := range req.Participants {
		fsmInstance.FSMDump().Payload.SetPubKeyUsername(reqParticipant.Name, reqParticipant.NewCommPubKey)
	}
	fsmDump, err := fsmInstance.Dump()
	if err != nil {
		return fmt.Errorf("failed to get FSM dump")
	}

	if err := s.fsmService.SaveFSM(message.DkgRoundID, fsmDump); err != nil {
		return fmt.Errorf("failed to SaveFSM: %w", err)
	}

```

The impact of this issue is that all node will update the communication public key to the value set by the attacker. The attacker can then control all messages sent via the protocol.
There is a second issue that is related. The verification of signatures is disabled during reinitDKG() then operations are executed. Therefore, it is possible for a node to send malicious message acting as another party and have them processed.This is done similarly to the previous attack by calling reinitDKG() setting req.DKGID as the current round.

```go
	// temporarily fix cause we can't verify patch messages
	// TODO: remove later
	if !s.GetSkipCommKeysVerification() {
		s.SetSkipCommKeysVerification(true)
		defer s.SetSkipCommKeysVerification(false)
	}

	operations := make([]*types.Operation, 0)
	for _, msg := range req.Messages {
		if fsm.Event(msg.Event) == sif.EventSigningStart {
			break
		}
		if msg.RecipientAddr == "" || msg.RecipientAddr == s.GetUsername() {
			operation, err := s.processMessage(msg)
			if err != nil {
				s.Logger.Log("failed to process operation: %v", err)
			}
			if operation != nil {
				operations = append(operations, operation)
			}
		}
	}
```

**Recommendations**
To resolve this issue prevent reinitDKG() from being called if req.DKGID is already in use.