### PR TITLE
fix: MUST use GENESIS_FORK_VERSION to sign BLSToExecutionChange message.

### DIFF
--- a/HowToSignBaked.md
+++ b/HowToSignBaked.md
@@ -43,9 +43,9 @@ class BLSToExecutionChange(Container):
 
 Dc4bc contains itself list of validator indexes embedded in [payload.csv](./pkg/wc_rotation/payloads.csv). Also, dc4bc predefined other values hex formatted and unit tests for them, such as:
 
-* [CapellaForkVersion](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/fork.md#configuration):
-  * ``0x03000000``
-  * ``[4]byte{3, 0, 0, 0}``
+* [GenesisForkVersion](https://github.com/ethereum/consensus-specs/blob/5337da5dff85cd584c4330b46a881510c1218ca3/specs/phase0/beacon-chain.md#genesis-settings):
+  * ``0x00000000``
+  * ``[4]byte{0, 0, 0, 0}``
 * [DomainBlsToExecutionChange](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#domain-types): 
     * ``0x0A000000``
     * ``[4]byte{10, 0, 0, 0}``

--- a/airgapped_setup/setup.sh
+++ b/airgapped_setup/setup.sh
@@ -6,11 +6,11 @@ while read -r sum _ ; do
   [[ $sum == 0ffd6499f8e2bb31d5321a6ec1ed5c2fcfb22f917a49a2b0c2d8b6fd379a1e7f ]] && echo "Firefox checksum is correct." || echo "[WARN] Incorrect Firefox checksum!"
 done
 
-wget -q --show-progress https://github.com/lidofinance/dc4bc/releases/download/4.0.0/build-linux-amd64.tar
+wget -q --show-progress https://github.com/lidofinance/dc4bc/releases/download/4.1.0/build-linux-amd64.tar
 tar -xvf build-linux-amd64.tar
 shasum ./build/dc4bc_airgapped |
 while read -r sum _ ; do
-  [[ $sum == 6508c7fd3b055d90f0725b188a59ebf7060255b3 ]] && echo "Airgapped checksum is correct." || echo "[WARN] Incorrect Airgapped checksum!"
+  [[ $sum == 594cec4feaee5c909c63c5713b26c0b5346dffe6 ]] && echo "Airgapped checksum is correct." || echo "[WARN] Incorrect Airgapped checksum!"
 done
 
 cp ../qr_reader_bundle/qr-tool.html ./qr-tool.html

--- a/pkg/wc_rotation/rotation.go
+++ b/pkg/wc_rotation/rotation.go
@@ -6,11 +6,6 @@ import (
 )
 
 var (
-	// CapellaForkVersion 0x03000000
-	//
-	// https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/fork.md#configuration
-	CapellaForkVersion = [4]byte{3, 0, 0, 0}
-
 	// GenesisForkVersion 0x00000000
 	//
 	// https://github.com/ethereum/consensus-specs/blob/5337da5dff85cd584c4330b46a881510c1218ca3/specs/phase0/beacon-chain.md#genesis-settings
@@ -44,7 +39,7 @@ var (
 func GetSigningRoot(validatorIndex uint64) ([32]byte, error) {
 	domain, computeDomainErr := computeDomain(
 		DomainBlsToExecutionChange,
-		CapellaForkVersion,
+		GenesisForkVersion,
 		GenesisValidatorRoot,
 	)
 

--- a/pkg/wc_rotation/rotation_test.go
+++ b/pkg/wc_rotation/rotation_test.go
@@ -20,7 +20,7 @@ func TestGetSigningRoot(t *testing.T) {
 			args: args{
 				validatorIndex: 393395,
 			},
-			want:    `5c57b22ed4078f4e4e8ec3188c8c25895154a55c62525488f40b37a3464da6fe`,
+			want:    `23ccffc7767e1b9a54b3e18c986f00d0345825bcab21eae5fe92c849d6cfedb4`,
 			wantErr: false,
 		},
 	}
@@ -36,7 +36,7 @@ func TestGetSigningRoot(t *testing.T) {
 			actual := hex.EncodeToString(got[:])
 
 			if actual != tt.want {
-				t.Errorf("GetSigningRoot() got = %v, want %v", got, tt.want)
+				t.Errorf("GetSigningRoot() got = %v, want %v", actual, tt.want)
 			}
 		})
 	}

--- a/pkg/wc_rotation/variables_test.go
+++ b/pkg/wc_rotation/variables_test.go
@@ -8,14 +8,6 @@ import (
 )
 
 func TestWCRotationVariables(t *testing.T) {
-	t.Run(`TestCapellaForkVersion`, func(t *testing.T) {
-		actual, _ := hex.DecodeString(`03000000`)
-
-		if bytes.Compare(actual, CapellaForkVersion[:]) != 0 {
-			t.Errorf("CapellaForkVersion is wrong got = %v, want %v", actual, CapellaForkVersion)
-		}
-	})
-
 	t.Run(`TestGenesisForkVersion`, func(t *testing.T) {
 		actual, _ := hex.DecodeString(`00000000`)
 


### PR DESCRIPTION
Support changes in eth consensus-specs.

Description - https://github.com/ethereum/consensus-specs/pull/3206